### PR TITLE
Fix error for mongo BSON document limit

### DIFF
--- a/properties.js
+++ b/properties.js
@@ -1,0 +1,7 @@
+/**
+ * Created by Stefan Schacherl on 24.11.2014.
+ */
+
+module.exports = {
+	maxSizeRequests: 100
+};

--- a/properties.js
+++ b/properties.js
@@ -1,7 +1,3 @@
-/**
- * Created by Stefan Schacherl on 24.11.2014.
- */
-
 module.exports = {
 	maxSizeRequests: 100
 };

--- a/server.js
+++ b/server.js
@@ -125,9 +125,8 @@ bin.recordRequest = function (req, res) {
             ip: req.ip
         });
 
-        if (bin.requests.length >= properties.maxSizeRequests) {
-            var amount = bin.requests.length - properties.maxSizeRequests + 1;
-            bin.requests.splice(0, amount);
+        if (bin.requests.length === properties.maxSizeRequests) {
+            bin.requests.shift();
         }
         bin.requests.push(request);
 

--- a/server.js
+++ b/server.js
@@ -5,7 +5,6 @@ var application_root = __dirname,
     path = require("path"),
     mongoose = require('mongoose'),
     properties = require('./properties.js'),
-    FifoArray = require('fifo-array'),
     Config = require('./config.js');
 
 var app = express(),
@@ -126,11 +125,12 @@ bin.recordRequest = function (req, res) {
             ip: req.ip
         });
 
-        var requests = new FifoArray(properties.maxSizeRequests, bin.requests);
-        requests.push(request);
-        bin.requests = requests;
-
-        bin.requests.push(request);
+        if (bin.requests.length >= properties.maxSizeRequests) {
+            var amount = bin.requests.length - properties.maxSizeRequests + 1;
+            bin.requests.splice(0, amount, request);
+        } else {
+            bin.requests.push(request);
+        }        
 
         return bin.save(function (err) {
             if (!err) {

--- a/server.js
+++ b/server.js
@@ -4,6 +4,8 @@ var application_root = __dirname,
     express = require("express"),
     path = require("path"),
     mongoose = require('mongoose'),
+    properties = require('./properties.js'),
+    FifoArray = require('fifo-array'),
     Config = require('./config.js');
 
 var app = express(),
@@ -98,7 +100,6 @@ bin.add = function (req, res) {
 
 bin.recordRequest = function (req, res) {
     return BinModel.findByReference(req.params.reference, function (err, bin) {
-
         if (bin === null) {
             return res.send(404);
         }
@@ -124,6 +125,10 @@ bin.recordRequest = function (req, res) {
             cookies: req.cookies,
             ip: req.ip
         });
+
+        var requests = new FifoArray(properties.maxSizeRequests, bin.requests);
+        requests.push(request);
+        bin.requests = requests;
 
         bin.requests.push(request);
 


### PR DESCRIPTION
*Added FiFo-Array as dependency to handle to many requests on a single bin
*Added propertie file to define max size of requests per bin
*Set default max size of requests per bin to 100

(at about 10.000 requests per bin parse error triggered when requesting bins)
